### PR TITLE
Add no-sandbox to chrome args to make it work in docker

### DIFF
--- a/src/browsers.ts
+++ b/src/browsers.ts
@@ -116,7 +116,7 @@ function chrome(browser: launchpad.Browser): wd.Capabilities {
     'version':     browser.version.match(/\d+/)[0],
     'chromeOptions': {
       'binary': browser.binPath,
-      'args': ['start-maximized','headless','disable-gpu']
+      'args': ['start-maximized','headless','disable-gpu', 'no-sandbox']
     },
   };
 }


### PR DESCRIPTION
I wanted to run wct tests with headless Chrome on Docker under Jenkins. The only way I found that works was to pass a "--no-sandbox" argument to Chrome, as suggested by others :

https://stackoverflow.com/questions/45025628/docker-selenium-headless-chrome-configure-suid-sandbox-correctly

https://hub.docker.com/r/armbues/chrome-headless/

This pull request would be useful for others with automated tests. The downsize is that normally it is more dangerous without sandbox. In case of WCT, we run it against unit tests, so no danger here I would say.

