### PR TITLE
Replace chromeOptions by browsersOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,13 @@ wct-headless plugin is derived from [wct-local](https://github.com/Polymer/wct-l
       "browsers": [
         "chrome"
       ],
-      "chromeOptions": [
-        "window-size=1920,1080",
-        "headless",
-        "disable-gpu"
-      ]
+      "browsersOptions": {
+        "chrome": [
+          "window-size=1920,1080",
+          "headless",
+          "disable-gpu"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
chromeOptions work fine but it's a bit specific to be passed around. If a new option is to be added one day, it would require adding yet another parameter everywhere. 

I propose to replace chromeOptions with browsersOptions.

This is just a quick proposition. If you like the change, I can make update Readme etc., 