### PR TITLE
Update cleankill so java process properly close after wct tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/node": "^6.0.31",
     "@types/which": "^1.0.27",
     "chalk": "^1.1.1",
-    "cleankill": "^1.0.3",
+    "cleankill": "^2.0.0",
     "freeport": "^1.0.4",
     "launchpad": "^0.6.0",
     "promisify-node": "^0.4.0",

--- a/src/selenium.ts
+++ b/src/selenium.ts
@@ -79,9 +79,8 @@ async function seleniumStart(
   // Bookkeeping once the process starts.
   config.spawnCb = function(server: child_process.ChildProcess) {
     // Make sure that we interrupt the selenium server ASAP.
-    cleankill.onInterrupt(function(done) {
+    cleankill.onInterrupt(async() => {
       server.kill();
-      done();
     });
 
     server.stdout.on('data', onOutput);


### PR DESCRIPTION
Cleankill was updated in wct-local after the release of 6.4.1 web-component-tester. wct-headless needs this update as well to properly kill java processes.