### PR TITLE
update promisify-node dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "cleankill": "^2.0.0",
     "freeport": "^1.0.4",
     "launchpad": "^0.6.0",
-    "promisify-node": "^0.4.0",
+    "promisify-node": "^0.5.0",
     "selenium-standalone": "^6.7.0",
     "which": "^1.0.8"
   },


### PR DESCRIPTION
This PR is a fix for Error
`TypeError: Cannot read property '1' of null`
In running headless test on node 12.

Like reported on here https://github.com/Polymer/tools/issues/3415